### PR TITLE
Improve css definitions for unselectable elements

### DIFF
--- a/examples/galculator.html
+++ b/examples/galculator.html
@@ -56,7 +56,6 @@
     .group { display:flex;     width:100%; }
     .numButton {
       position     : relative;
-      user-select  : none;
       outline      : none;
       width        : 70px;
       flex-grow    : 1;
@@ -74,10 +73,12 @@
                      inset 0px -1px 1px rgba(70,50,40,0.8),
                      inset 0px -2px 1px rgba(90,50,40,0.3);
       cursor       : pointer;
+    }
+    .noselect {
       -webkit-user-select : none;
-      -moz-user-select    : none; 
+      -moz-user-select    : none;
       -ms-user-select     : none;
-      user-select         : none; 
+      user-select         : none;
     }
     .numButton:focus { outline:none; }
     .numButton:active:not(.disabled), .numButton.active:not(.disabled) { top:2px; }
@@ -439,7 +440,7 @@
      // Every 8 buttons, start a new group.
        if (j%8==0) p = document.getElementById("calcBody").appendChild(Object.assign(document.createElement('div'),{className:'group'}));
      // Add the button to the current group.  
-       buttons[i].el = p.appendChild( Object.assign(document.createElement('div'),{className:"numButton "+(buttons[i].color||''),innerHTML:buttons[i].label}) );
+       buttons[i].el = p.appendChild( Object.assign(document.createElement('div'),{className:"numButton noselect "+(buttons[i].color||''),innerHTML:buttons[i].label}) );
      // Link the handlers  
        (function(x){ 
          buttons[i].el.ontouchend = function(e) { this.classList.remove('active'); }

--- a/ganja.js
+++ b/ganja.js
@@ -333,7 +333,7 @@
           // Reset position and color for cursor.  
             lx=-2;ly=-1.85;lr=0;color='#444'; 
           // Create the svg element. (master template string till end of function)  
-            var svg=new DOMParser().parseFromString(`<SVG onmousedown="if(evt.target==this)this.sel=undefined" viewBox="-2 -${2*(hh/ww||1)} 4 ${4*(hh/ww||1)}" style="width:${ww||512}px; height:${hh||512}px; background-color:#eee; user-select:none">
+            var svg=new DOMParser().parseFromString(`<SVG onmousedown="if(evt.target==this)this.sel=undefined" viewBox="-2 -${2*(hh/ww||1)} 4 ${4*(hh/ww||1)}" style="width:${ww||512}px; height:${hh||512}px; background-color:#eee; -webkit-user-select:none; -moz-user-select:none; -ms-user-select:none; user-select:none">
             // Add a grid (option)
             ${options.grid?[...Array(11)].map((x,xi)=>`<line x1="-10" y1="${(xi-5)/2}" x2="10" y2="${(xi-5)/2}" stroke-width="0.005" stroke="#CCC"/><line y1="-10" x1="${(xi-5)/2}" y2="10" x2="${(xi-5)/2}"  stroke-width="0.005" stroke="#CCC"/>`):''}
             // Handle conformal 2D elements. 


### PR DESCRIPTION
- galculator.html: group all browser-specific rules for nonselectable text
  under the same ruleset (also remove a duplicate rule and EOL whitespace)
- ganja.js: add browser-specific selectors

For additional context/background, see #4 and #7.