### PR TITLE
Support generating for only some languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+codegen/out*

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -14,7 +14,21 @@ To be able to compile for all languages, you need :
 * python
 * rust (nightly) (run "rustup default nightly" in the project folder)
 
-With those installed, simply run the makefile.
+With those installed, simply run `make`.
+
+If you wish to generate and compile for only some of these languages or algebras, run something like
+
+```bash
+make GEN_LANG="csharp cpp python rust" c hyperbolic dual r2 r3 mink quat r111 spacetime cga pga3d
+```
+
+with languages or algebras you don't need removed from the command parameters.
+
+For example, if you only want pga3d for rust, just run:
+
+```bash
+make GEN_LANG="rust" pga3d
+```
 
 ## Pregenerated sources
 

--- a/codegen/makefile
+++ b/codegen/makefile
@@ -1,23 +1,25 @@
 ## Minimalistic, I'm using this on ubuntu, with g++ and mono default installs and node v11
 ALL: c hyperbolic dual r2 r3 mink quat r111 spacetime cga pga3d
-
-ALL:
 	@echo "done !"
+
+## Generate all languages by default
+GEN_LANG=${GEN_LANG:-"csharp cpp python rust"}
 
 %:
 	@node generate `echo $*| tr "[a-z]" "[A-Z]"`
-	@mcs -out:$*_cs.exe $*.cs
-	@g++ -o $*_cpp $*.cpp -std=c++11
-	@rustc -o $*_rust $*.rs
-	@echo "CPP" $* > out1; ./$*_cpp >> out1
-	@echo "C#" $* > out2; mono $*_cs.exe >> out2
-	@echo "PYTHON" $* > out3; python $*.py >> out3
-	@echo "RUST" $* > out4; ./$*_rust >> out4
+	@echo "CPP" $* > out1
+	@echo "C#" $* > out2
+	@echo "PYTHON" $* > out3
+	@echo "RUST" $* > out4
+	@if [[ $GEN_LANG == *"cpp"* ]]; then g++ -o cpp/$*_cpp cpp/$*.cpp -std=c++11; ./cpp/$*_cpp >> out1; fi
+	@if [[ $GEN_LANG == *"csharp"* ]]; then mcs -out:csharp/$*_cs.exe csharp/$*.cs;  mono ./csharp/$*_cs.exe >> out2; fi
+	@if [[ $GEN_LANG == *"python"* ]]; then python ./python/$*.py >> out3; fi
+	@if [[ $GEN_LANG == *"rust"* ]]; then rustc -o rust/$*_rust rust/$*.rs; ./rust/$*_rust >> out4; fi
 	@diff -y out1 out2 -W 110 > out12 || true; diff -y out3 out4 -W 110 > out34 || true; colordiff -yW 220 out12 out34 || true; rm out1 out2 out3 out4 out12 out34
 	@echo
 
 ## rough clean generated files	
 clean:
 	@echo "cleaning .."
-	-@rm pga* cga* r3* r2* quat* spacetime* c_* c.* mink* *.cs *.cpp *.py *.exe *.rs *_cpp *_rust  -f
+	-@rm {csharp,cpp,python,rust}/*{.cs,.cpp,.py,.exe,.rs,_cpp,_rust}  -f
 	-@rm *~ -f


### PR DESCRIPTION
As described in the modified README:

>If you wish to generate and compile for only some of these languages or algebras, run something like
>
> ```bash
> make GEN_LANG="csharp cpp python rust" c hyperbolic dual r2 r3 mink quat r111 spacetime cga pga3d
> ```
> 
> with languages or algebras you don't need removed from the command parameters.
> 
> For example, if you only want pga3d for rust, just run:
> 
> ```bash
> make GEN_LANG="rust" pga3d
> ```

Additionally, it also ensures that the files generated for each language fall into separate directories per language and the corresponding directories will be created automatically.

RFC.