### PR TITLE
Init algebra from array in python

### DIFF
--- a/codegen/py.template.js
+++ b/codegen/py.template.js
@@ -219,7 +219,7 @@ if __name__ == '__main__':
 // python Template for the postamble
 var postamble = (basis,classname,example)=>
 `    def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/py.template.js
+++ b/codegen/py.template.js
@@ -19,9 +19,32 @@ class ${classname}:
         self._base = [${basis.map(x=>'"'+x+'"').join(', ')}]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new ${classname} from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of ${classname}.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -43,11 +66,11 @@ var binary = (classname, symbol, name, name_a, name_b, name_ret, code, classname
         
         ${desc}
         """
-        if type(b) in (int, float):
-            return a.${name.toLowerCase()}s(b)`:``}
-        ${name_ret} = ${classname}()
+        if type(${name_b}) in (int, float):
+            return ${name_a}.${name.toLowerCase()}s(${name_b})`:``}
+        ${name_ret} = ${name_a}.mvec.copy()
         ${code.replace(/;/g,'').replace(/^ */g,'').replace(/\n */g,'\n        ')}
-        return ${name_ret}
+        return ${classname}.fromarray(${name_ret})
 ${(name in {Mul:1,Add:1,Sub:1})?`    __r${name.toLowerCase()}__=__${name.toLowerCase()}__`:``}`;
 
 // python Template for our unary operators
@@ -58,9 +81,9 @@ var unary = (classname, symbol, name, name_a, name_ret, code, classname_a=classn
         
         ${desc}
         """
-        ${name_ret} = ${classname}()
+        ${name_ret} = ${name_a}.mvec.copy()
         ${code.replace(/;/g,'').replace(/^ */g,'').replace(/\n */g,'\n        ')}
-        return ${name_ret}`;
+        return ${classname}.fromarray(${name_ret})`;
 
 // python template for CGA example
 var CGA = (basis,classname)=>({

--- a/codegen/python/c.py
+++ b/codegen/python/c.py
@@ -17,9 +17,32 @@ class C:
         self._base = ["1", "e1"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new C from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of C.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,40 +61,40 @@ class C:
         
         Reverse the order of the basis blades.
         """
-        res = C()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
-        return res
+        return C.fromarray(res)
 
     def Dual(a):
         """C.Dual
         
         Poincare duality operator.
         """
-        res = C()
+        res = a.mvec.copy()
         res[0]=-a[1]
         res[1]=a[0]
-        return res
+        return C.fromarray(res)
 
     def Conjugate(a):
         """C.Conjugate
         
         Clifford Conjugation
         """
-        res = C()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return C.fromarray(res)
 
     def Involute(a):
         """C.Involute
         
         Main involution
         """
-        res = C()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return C.fromarray(res)
 
     def __mul__(a,b):
         """C.Mul
@@ -80,31 +103,31 @@ class C:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = C()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]-b[1]*a[1]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return C.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return C.fromarray(res)
 
 
     def __and__(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[1]=b[1]*a[1]
         res[0]=b[0]*a[1]+b[1]*a[0]
-        return res
+        return C.fromarray(res)
 
 
     def __or__(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]-b[1]*a[1]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return C.fromarray(res)
 
 
     def __add__(a,b):
@@ -114,10 +137,10 @@ class C:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = C()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
-        return res
+        return C.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -127,42 +150,42 @@ class C:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = C()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
-        return res
+        return C.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
-        return res
+        return C.fromarray(res)
 
 
     def muls(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
-        return res
+        return C.fromarray(res)
 
 
     def sadd(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
-        return res
+        return C.fromarray(res)
 
 
     def adds(a,b):
-        res = C()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
-        return res
+        return C.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/cga.py
+++ b/codegen/python/cga.py
@@ -17,9 +17,32 @@ class CGA:
         self._base = ["1", "e1", "e2", "e3", "e4", "e5", "e12", "e13", "e14", "e15", "e23", "e24", "e25", "e34", "e35", "e45", "e123", "e124", "e125", "e134", "e135", "e145", "e234", "e235", "e245", "e345", "e1234", "e1235", "e1245", "e1345", "e2345", "e12345"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new CGA from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of CGA.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,7 +61,7 @@ class CGA:
         
         Reverse the order of the basis blades.
         """
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
@@ -71,14 +94,14 @@ class CGA:
         res[29]=a[29]
         res[30]=a[30]
         res[31]=a[31]
-        return res
+        return CGA.fromarray(res)
 
     def Dual(a):
         """CGA.Dual
         
         Poincare duality operator.
         """
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=-a[31]
         res[1]=-a[30]
         res[2]=a[29]
@@ -111,14 +134,14 @@ class CGA:
         res[29]=-a[2]
         res[30]=a[1]
         res[31]=a[0]
-        return res
+        return CGA.fromarray(res)
 
     def Conjugate(a):
         """CGA.Conjugate
         
         Clifford Conjugation
         """
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -151,14 +174,14 @@ class CGA:
         res[29]=a[29]
         res[30]=a[30]
         res[31]=-a[31]
-        return res
+        return CGA.fromarray(res)
 
     def Involute(a):
         """CGA.Involute
         
         Main involution
         """
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -191,7 +214,7 @@ class CGA:
         res[29]=a[29]
         res[30]=a[30]
         res[31]=-a[31]
-        return res
+        return CGA.fromarray(res)
 
     def __mul__(a,b):
         """CGA.Mul
@@ -200,7 +223,7 @@ class CGA:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]+b[4]*a[4]-b[5]*a[5]-b[6]*a[6]-b[7]*a[7]-b[8]*a[8]+b[9]*a[9]-b[10]*a[10]-b[11]*a[11]+b[12]*a[12]-b[13]*a[13]+b[14]*a[14]+b[15]*a[15]-b[16]*a[16]-b[17]*a[17]+b[18]*a[18]-b[19]*a[19]+b[20]*a[20]+b[21]*a[21]-b[22]*a[22]+b[23]*a[23]+b[24]*a[24]+b[25]*a[25]+b[26]*a[26]-b[27]*a[27]-b[28]*a[28]-b[29]*a[29]-b[30]*a[30]-b[31]*a[31]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[6]*a[2]-b[7]*a[3]-b[8]*a[4]+b[9]*a[5]+b[2]*a[6]+b[3]*a[7]+b[4]*a[8]-b[5]*a[9]-b[16]*a[10]-b[17]*a[11]+b[18]*a[12]-b[19]*a[13]+b[20]*a[14]+b[21]*a[15]-b[10]*a[16]-b[11]*a[17]+b[12]*a[18]-b[13]*a[19]+b[14]*a[20]+b[15]*a[21]+b[26]*a[22]-b[27]*a[23]-b[28]*a[24]-b[29]*a[25]-b[22]*a[26]+b[23]*a[27]+b[24]*a[28]+b[25]*a[29]-b[31]*a[30]-b[30]*a[31]
         res[2]=b[2]*a[0]+b[6]*a[1]+b[0]*a[2]-b[10]*a[3]-b[11]*a[4]+b[12]*a[5]-b[1]*a[6]+b[16]*a[7]+b[17]*a[8]-b[18]*a[9]+b[3]*a[10]+b[4]*a[11]-b[5]*a[12]-b[22]*a[13]+b[23]*a[14]+b[24]*a[15]+b[7]*a[16]+b[8]*a[17]-b[9]*a[18]-b[26]*a[19]+b[27]*a[20]+b[28]*a[21]-b[13]*a[22]+b[14]*a[23]+b[15]*a[24]-b[30]*a[25]+b[19]*a[26]-b[20]*a[27]-b[21]*a[28]+b[31]*a[29]+b[25]*a[30]+b[29]*a[31]
@@ -233,11 +256,11 @@ class CGA:
         res[29]=b[29]*a[0]+b[25]*a[1]-b[31]*a[2]-b[21]*a[3]+b[20]*a[4]-b[19]*a[5]+b[30]*a[6]+b[15]*a[7]-b[14]*a[8]+b[13]*a[9]-b[28]*a[10]+b[27]*a[11]-b[26]*a[12]+b[9]*a[13]-b[8]*a[14]+b[7]*a[15]-b[24]*a[16]+b[23]*a[17]-b[22]*a[18]+b[5]*a[19]-b[4]*a[20]+b[3]*a[21]-b[18]*a[22]+b[17]*a[23]-b[16]*a[24]-b[1]*a[25]+b[12]*a[26]-b[11]*a[27]+b[10]*a[28]+b[0]*a[29]-b[6]*a[30]-b[2]*a[31]
         res[30]=b[30]*a[0]+b[31]*a[1]+b[25]*a[2]-b[24]*a[3]+b[23]*a[4]-b[22]*a[5]-b[29]*a[6]+b[28]*a[7]-b[27]*a[8]+b[26]*a[9]+b[15]*a[10]-b[14]*a[11]+b[13]*a[12]+b[12]*a[13]-b[11]*a[14]+b[10]*a[15]+b[21]*a[16]-b[20]*a[17]+b[19]*a[18]+b[18]*a[19]-b[17]*a[20]+b[16]*a[21]+b[5]*a[22]-b[4]*a[23]+b[3]*a[24]-b[2]*a[25]-b[9]*a[26]+b[8]*a[27]-b[7]*a[28]+b[6]*a[29]+b[0]*a[30]+b[1]*a[31]
         res[31]=b[31]*a[0]+b[30]*a[1]-b[29]*a[2]+b[28]*a[3]-b[27]*a[4]+b[26]*a[5]+b[25]*a[6]-b[24]*a[7]+b[23]*a[8]-b[22]*a[9]+b[21]*a[10]-b[20]*a[11]+b[19]*a[12]+b[18]*a[13]-b[17]*a[14]+b[16]*a[15]+b[15]*a[16]-b[14]*a[17]+b[13]*a[18]+b[12]*a[19]-b[11]*a[20]+b[10]*a[21]-b[9]*a[22]+b[8]*a[23]-b[7]*a[24]+b[6]*a[25]+b[5]*a[26]-b[4]*a[27]+b[3]*a[28]-b[2]*a[29]+b[1]*a[30]+b[0]*a[31]
-        return res
+        return CGA.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
@@ -270,11 +293,11 @@ class CGA:
         res[29]=b[29]*a[0]+b[25]*a[1]-b[21]*a[3]+b[20]*a[4]-b[19]*a[5]+b[15]*a[7]-b[14]*a[8]+b[13]*a[9]+b[9]*a[13]-b[8]*a[14]+b[7]*a[15]+b[5]*a[19]-b[4]*a[20]+b[3]*a[21]-b[1]*a[25]+b[0]*a[29]
         res[30]=b[30]*a[0]+b[25]*a[2]-b[24]*a[3]+b[23]*a[4]-b[22]*a[5]+b[15]*a[10]-b[14]*a[11]+b[13]*a[12]+b[12]*a[13]-b[11]*a[14]+b[10]*a[15]+b[5]*a[22]-b[4]*a[23]+b[3]*a[24]-b[2]*a[25]+b[0]*a[30]
         res[31]=b[31]*a[0]+b[30]*a[1]-b[29]*a[2]+b[28]*a[3]-b[27]*a[4]+b[26]*a[5]+b[25]*a[6]-b[24]*a[7]+b[23]*a[8]-b[22]*a[9]+b[21]*a[10]-b[20]*a[11]+b[19]*a[12]+b[18]*a[13]-b[17]*a[14]+b[16]*a[15]+b[15]*a[16]-b[14]*a[17]+b[13]*a[18]+b[12]*a[19]-b[11]*a[20]+b[10]*a[21]-b[9]*a[22]+b[8]*a[23]-b[7]*a[24]+b[6]*a[25]+b[5]*a[26]-b[4]*a[27]+b[3]*a[28]-b[2]*a[29]+b[1]*a[30]+b[0]*a[31]
-        return res
+        return CGA.fromarray(res)
 
 
     def __and__(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[31]=b[31]*a[31]
         res[30]=b[30]*a[31]+b[31]*a[30]
         res[29]=b[29]*a[31]+b[31]*a[29]
@@ -307,11 +330,11 @@ class CGA:
         res[2]=b[2]*a[31]+b[6]*a[30]-b[10]*a[28]+b[11]*a[27]-b[12]*a[26]+b[16]*a[24]-b[17]*a[23]+b[18]*a[22]+b[22]*a[18]-b[23]*a[17]+b[24]*a[16]+b[26]*a[12]-b[27]*a[11]+b[28]*a[10]-b[30]*a[6]+b[31]*a[2]
         res[1]=b[1]*a[31]+b[6]*a[29]-b[7]*a[28]+b[8]*a[27]-b[9]*a[26]+b[16]*a[21]-b[17]*a[20]+b[18]*a[19]+b[19]*a[18]-b[20]*a[17]+b[21]*a[16]+b[26]*a[9]-b[27]*a[8]+b[28]*a[7]-b[29]*a[6]+b[31]*a[1]
         res[0]=b[0]*a[31]+b[1]*a[30]-b[2]*a[29]+b[3]*a[28]-b[4]*a[27]+b[5]*a[26]+b[6]*a[25]-b[7]*a[24]+b[8]*a[23]-b[9]*a[22]+b[10]*a[21]-b[11]*a[20]+b[12]*a[19]+b[13]*a[18]-b[14]*a[17]+b[15]*a[16]+b[16]*a[15]-b[17]*a[14]+b[18]*a[13]+b[19]*a[12]-b[20]*a[11]+b[21]*a[10]-b[22]*a[9]+b[23]*a[8]-b[24]*a[7]+b[25]*a[6]+b[26]*a[5]-b[27]*a[4]+b[28]*a[3]-b[29]*a[2]+b[30]*a[1]+b[31]*a[0]
-        return res
+        return CGA.fromarray(res)
 
 
     def __or__(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]+b[4]*a[4]-b[5]*a[5]-b[6]*a[6]-b[7]*a[7]-b[8]*a[8]+b[9]*a[9]-b[10]*a[10]-b[11]*a[11]+b[12]*a[12]-b[13]*a[13]+b[14]*a[14]+b[15]*a[15]-b[16]*a[16]-b[17]*a[17]+b[18]*a[18]-b[19]*a[19]+b[20]*a[20]+b[21]*a[21]-b[22]*a[22]+b[23]*a[23]+b[24]*a[24]+b[25]*a[25]+b[26]*a[26]-b[27]*a[27]-b[28]*a[28]-b[29]*a[29]-b[30]*a[30]-b[31]*a[31]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[6]*a[2]-b[7]*a[3]-b[8]*a[4]+b[9]*a[5]+b[2]*a[6]+b[3]*a[7]+b[4]*a[8]-b[5]*a[9]-b[16]*a[10]-b[17]*a[11]+b[18]*a[12]-b[19]*a[13]+b[20]*a[14]+b[21]*a[15]-b[10]*a[16]-b[11]*a[17]+b[12]*a[18]-b[13]*a[19]+b[14]*a[20]+b[15]*a[21]+b[26]*a[22]-b[27]*a[23]-b[28]*a[24]-b[29]*a[25]-b[22]*a[26]+b[23]*a[27]+b[24]*a[28]+b[25]*a[29]-b[31]*a[30]-b[30]*a[31]
         res[2]=b[2]*a[0]+b[6]*a[1]+b[0]*a[2]-b[10]*a[3]-b[11]*a[4]+b[12]*a[5]-b[1]*a[6]+b[16]*a[7]+b[17]*a[8]-b[18]*a[9]+b[3]*a[10]+b[4]*a[11]-b[5]*a[12]-b[22]*a[13]+b[23]*a[14]+b[24]*a[15]+b[7]*a[16]+b[8]*a[17]-b[9]*a[18]-b[26]*a[19]+b[27]*a[20]+b[28]*a[21]-b[13]*a[22]+b[14]*a[23]+b[15]*a[24]-b[30]*a[25]+b[19]*a[26]-b[20]*a[27]-b[21]*a[28]+b[31]*a[29]+b[25]*a[30]+b[29]*a[31]
@@ -344,7 +367,7 @@ class CGA:
         res[29]=b[29]*a[0]-b[31]*a[2]+b[0]*a[29]-b[2]*a[31]
         res[30]=b[30]*a[0]+b[31]*a[1]+b[0]*a[30]+b[1]*a[31]
         res[31]=b[31]*a[0]+b[0]*a[31]
-        return res
+        return CGA.fromarray(res)
 
 
     def __add__(a,b):
@@ -354,7 +377,7 @@ class CGA:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
@@ -387,7 +410,7 @@ class CGA:
         res[29] = a[29]+b[29]
         res[30] = a[30]+b[30]
         res[31] = a[31]+b[31]
-        return res
+        return CGA.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -397,7 +420,7 @@ class CGA:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
@@ -430,11 +453,11 @@ class CGA:
         res[29] = a[29]-b[29]
         res[30] = a[30]-b[30]
         res[31] = a[31]-b[31]
-        return res
+        return CGA.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
@@ -467,11 +490,11 @@ class CGA:
         res[29] = a*b[29]
         res[30] = a*b[30]
         res[31] = a*b[31]
-        return res
+        return CGA.fromarray(res)
 
 
     def muls(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
@@ -504,11 +527,11 @@ class CGA:
         res[29] = a[29]*b
         res[30] = a[30]*b
         res[31] = a[31]*b
-        return res
+        return CGA.fromarray(res)
 
 
     def sadd(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
@@ -541,11 +564,11 @@ class CGA:
         res[29] = b[29]
         res[30] = b[30]
         res[31] = b[31]
-        return res
+        return CGA.fromarray(res)
 
 
     def adds(a,b):
-        res = CGA()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
@@ -578,11 +601,11 @@ class CGA:
         res[29] = a[29]
         res[30] = a[30]
         res[31] = a[31]
-        return res
+        return CGA.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/dual.py
+++ b/codegen/python/dual.py
@@ -17,9 +17,32 @@ class DUAL:
         self._base = ["1", "e0"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new DUAL from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of DUAL.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,40 +61,40 @@ class DUAL:
         
         Reverse the order of the basis blades.
         """
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
-        return res
+        return DUAL.fromarray(res)
 
     def Dual(a):
         """DUAL.Dual
         
         Poincare duality operator.
         """
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=a[1]
         res[1]=a[0]
-        return res
+        return DUAL.fromarray(res)
 
     def Conjugate(a):
         """DUAL.Conjugate
         
         Clifford Conjugation
         """
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return DUAL.fromarray(res)
 
     def Involute(a):
         """DUAL.Involute
         
         Main involution
         """
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return DUAL.fromarray(res)
 
     def __mul__(a,b):
         """DUAL.Mul
@@ -80,31 +103,31 @@ class DUAL:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return DUAL.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return DUAL.fromarray(res)
 
 
     def __and__(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[1]=b[1]*a[1]
         res[0]=b[0]*a[1]+b[1]*a[0]
-        return res
+        return DUAL.fromarray(res)
 
 
     def __or__(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return DUAL.fromarray(res)
 
 
     def __add__(a,b):
@@ -114,10 +137,10 @@ class DUAL:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
-        return res
+        return DUAL.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -127,42 +150,42 @@ class DUAL:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
-        return res
+        return DUAL.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
-        return res
+        return DUAL.fromarray(res)
 
 
     def muls(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
-        return res
+        return DUAL.fromarray(res)
 
 
     def sadd(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
-        return res
+        return DUAL.fromarray(res)
 
 
     def adds(a,b):
-        res = DUAL()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
-        return res
+        return DUAL.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/hyperbolic.py
+++ b/codegen/python/hyperbolic.py
@@ -17,9 +17,32 @@ class HYPERBOLIC:
         self._base = ["1", "e1"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new HYPERBOLIC from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of HYPERBOLIC.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,40 +61,40 @@ class HYPERBOLIC:
         
         Reverse the order of the basis blades.
         """
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
     def Dual(a):
         """HYPERBOLIC.Dual
         
         Poincare duality operator.
         """
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=a[1]
         res[1]=a[0]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
     def Conjugate(a):
         """HYPERBOLIC.Conjugate
         
         Clifford Conjugation
         """
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
     def Involute(a):
         """HYPERBOLIC.Involute
         
         Main involution
         """
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
     def __mul__(a,b):
         """HYPERBOLIC.Mul
@@ -80,31 +103,31 @@ class HYPERBOLIC:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def __and__(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[1]=b[1]*a[1]
         res[0]=b[0]*a[1]+b[1]*a[0]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def __or__(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]
         res[1]=b[1]*a[0]+b[0]*a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def __add__(a,b):
@@ -114,10 +137,10 @@ class HYPERBOLIC:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -127,42 +150,42 @@ class HYPERBOLIC:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def muls(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def sadd(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def adds(a,b):
-        res = HYPERBOLIC()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
-        return res
+        return HYPERBOLIC.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/mink.py
+++ b/codegen/python/mink.py
@@ -17,9 +17,32 @@ class MINK:
         self._base = ["1", "e1", "e2", "e12"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new MINK from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of MINK.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,48 +61,48 @@ class MINK:
         
         Reverse the order of the basis blades.
         """
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
         res[3]=-a[3]
-        return res
+        return MINK.fromarray(res)
 
     def Dual(a):
         """MINK.Dual
         
         Poincare duality operator.
         """
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=a[3]
         res[1]=-a[2]
         res[2]=-a[1]
         res[3]=a[0]
-        return res
+        return MINK.fromarray(res)
 
     def Conjugate(a):
         """MINK.Conjugate
         
         Clifford Conjugation
         """
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=-a[3]
-        return res
+        return MINK.fromarray(res)
 
     def Involute(a):
         """MINK.Involute
         
         Main involution
         """
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=a[3]
-        return res
+        return MINK.fromarray(res)
 
     def __mul__(a,b):
         """MINK.Mul
@@ -88,39 +111,39 @@ class MINK:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]-b[2]*a[2]+b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]+b[3]*a[2]-b[2]*a[3]
         res[2]=b[2]*a[0]+b[3]*a[1]+b[0]*a[2]-b[1]*a[3]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return MINK.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return MINK.fromarray(res)
 
 
     def __and__(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[3]=b[3]*a[3]
         res[2]=b[2]*a[3]+b[3]*a[2]
         res[1]=b[1]*a[3]+b[3]*a[1]
         res[0]=b[0]*a[3]+b[1]*a[2]-b[2]*a[1]+b[3]*a[0]
-        return res
+        return MINK.fromarray(res)
 
 
     def __or__(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]-b[2]*a[2]+b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]+b[3]*a[2]-b[2]*a[3]
         res[2]=b[2]*a[0]+b[3]*a[1]+b[0]*a[2]-b[1]*a[3]
         res[3]=b[3]*a[0]+b[0]*a[3]
-        return res
+        return MINK.fromarray(res)
 
 
     def __add__(a,b):
@@ -130,12 +153,12 @@ class MINK:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
         res[3] = a[3]+b[3]
-        return res
+        return MINK.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -145,52 +168,52 @@ class MINK:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
         res[3] = a[3]-b[3]
-        return res
+        return MINK.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
         res[3] = a*b[3]
-        return res
+        return MINK.fromarray(res)
 
 
     def muls(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
         res[3] = a[3]*b
-        return res
+        return MINK.fromarray(res)
 
 
     def sadd(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
         res[3] = b[3]
-        return res
+        return MINK.fromarray(res)
 
 
     def adds(a,b):
-        res = MINK()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
         res[3] = a[3]
-        return res
+        return MINK.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/pga3d.py
+++ b/codegen/python/pga3d.py
@@ -17,9 +17,32 @@ class PGA3D:
         self._base = ["1", "e0", "e1", "e2", "e3", "e01", "e02", "e03", "e12", "e31", "e23", "e021", "e013", "e032", "e123", "e0123"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new PGA3D from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of PGA3D.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,7 +61,7 @@ class PGA3D:
         
         Reverse the order of the basis blades.
         """
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
@@ -55,14 +78,14 @@ class PGA3D:
         res[13]=-a[13]
         res[14]=-a[14]
         res[15]=a[15]
-        return res
+        return PGA3D.fromarray(res)
 
     def Dual(a):
         """PGA3D.Dual
         
         Poincare duality operator.
         """
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=a[15]
         res[1]=a[14]
         res[2]=a[13]
@@ -79,14 +102,14 @@ class PGA3D:
         res[13]=a[2]
         res[14]=a[1]
         res[15]=a[0]
-        return res
+        return PGA3D.fromarray(res)
 
     def Conjugate(a):
         """PGA3D.Conjugate
         
         Clifford Conjugation
         """
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -103,14 +126,14 @@ class PGA3D:
         res[13]=a[13]
         res[14]=a[14]
         res[15]=a[15]
-        return res
+        return PGA3D.fromarray(res)
 
     def Involute(a):
         """PGA3D.Involute
         
         Main involution
         """
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -127,7 +150,7 @@ class PGA3D:
         res[13]=-a[13]
         res[14]=-a[14]
         res[15]=a[15]
-        return res
+        return PGA3D.fromarray(res)
 
     def __mul__(a,b):
         """PGA3D.Mul
@@ -136,7 +159,7 @@ class PGA3D:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[2]*a[2]+b[3]*a[3]+b[4]*a[4]-b[8]*a[8]-b[9]*a[9]-b[10]*a[10]-b[14]*a[14]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[5]*a[2]-b[6]*a[3]-b[7]*a[4]+b[2]*a[5]+b[3]*a[6]+b[4]*a[7]+b[11]*a[8]+b[12]*a[9]+b[13]*a[10]+b[8]*a[11]+b[9]*a[12]+b[10]*a[13]+b[15]*a[14]-b[14]*a[15]
         res[2]=b[2]*a[0]+b[0]*a[2]-b[8]*a[3]+b[9]*a[4]+b[3]*a[8]-b[4]*a[9]-b[14]*a[10]-b[10]*a[14]
@@ -153,11 +176,11 @@ class PGA3D:
         res[13]=b[13]*a[0]-b[10]*a[1]+b[15]*a[2]+b[7]*a[3]-b[6]*a[4]-b[14]*a[5]-b[4]*a[6]+b[3]*a[7]+b[12]*a[8]-b[11]*a[9]-b[1]*a[10]+b[9]*a[11]-b[8]*a[12]+b[0]*a[13]+b[5]*a[14]-b[2]*a[15]
         res[14]=b[14]*a[0]+b[10]*a[2]+b[9]*a[3]+b[8]*a[4]+b[4]*a[8]+b[3]*a[9]+b[2]*a[10]+b[0]*a[14]
         res[15]=b[15]*a[0]+b[14]*a[1]+b[13]*a[2]+b[12]*a[3]+b[11]*a[4]+b[10]*a[5]+b[9]*a[6]+b[8]*a[7]+b[7]*a[8]+b[6]*a[9]+b[5]*a[10]-b[4]*a[11]-b[3]*a[12]-b[2]*a[13]-b[1]*a[14]+b[0]*a[15]
-        return res
+        return PGA3D.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
@@ -174,11 +197,11 @@ class PGA3D:
         res[13]=b[13]*a[0]-b[10]*a[1]+b[7]*a[3]-b[6]*a[4]-b[4]*a[6]+b[3]*a[7]-b[1]*a[10]+b[0]*a[13]
         res[14]=b[14]*a[0]+b[10]*a[2]+b[9]*a[3]+b[8]*a[4]+b[4]*a[8]+b[3]*a[9]+b[2]*a[10]+b[0]*a[14]
         res[15]=b[15]*a[0]+b[14]*a[1]+b[13]*a[2]+b[12]*a[3]+b[11]*a[4]+b[10]*a[5]+b[9]*a[6]+b[8]*a[7]+b[7]*a[8]+b[6]*a[9]+b[5]*a[10]-b[4]*a[11]-b[3]*a[12]-b[2]*a[13]-b[1]*a[14]+b[0]*a[15]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def __and__(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[15]=b[15]*a[15]
         res[14]=b[14]*a[15]+b[15]*a[14]
         res[13]=b[13]*a[15]+b[15]*a[13]
@@ -195,11 +218,11 @@ class PGA3D:
         res[2]=b[2]*a[15]-b[5]*a[14]+b[8]*a[12]-b[9]*a[11]-b[11]*a[9]+b[12]*a[8]-b[14]*a[5]+b[15]*a[2]
         res[1]=b[1]*a[15]+b[5]*a[13]+b[6]*a[12]+b[7]*a[11]+b[11]*a[7]+b[12]*a[6]+b[13]*a[5]+b[15]*a[1]
         res[0]=b[0]*a[15]+b[1]*a[14]+b[2]*a[13]+b[3]*a[12]+b[4]*a[11]+b[5]*a[10]+b[6]*a[9]+b[7]*a[8]+b[8]*a[7]+b[9]*a[6]+b[10]*a[5]-b[11]*a[4]-b[12]*a[3]-b[13]*a[2]-b[14]*a[1]+b[15]*a[0]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def __or__(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[2]*a[2]+b[3]*a[3]+b[4]*a[4]-b[8]*a[8]-b[9]*a[9]-b[10]*a[10]-b[14]*a[14]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[5]*a[2]-b[6]*a[3]-b[7]*a[4]+b[2]*a[5]+b[3]*a[6]+b[4]*a[7]+b[11]*a[8]+b[12]*a[9]+b[13]*a[10]+b[8]*a[11]+b[9]*a[12]+b[10]*a[13]+b[15]*a[14]-b[14]*a[15]
         res[2]=b[2]*a[0]+b[0]*a[2]-b[8]*a[3]+b[9]*a[4]+b[3]*a[8]-b[4]*a[9]-b[14]*a[10]-b[10]*a[14]
@@ -216,7 +239,7 @@ class PGA3D:
         res[13]=b[13]*a[0]+b[15]*a[2]+b[0]*a[13]-b[2]*a[15]
         res[14]=b[14]*a[0]+b[0]*a[14]
         res[15]=b[15]*a[0]+b[0]*a[15]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def __add__(a,b):
@@ -226,7 +249,7 @@ class PGA3D:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
@@ -243,7 +266,7 @@ class PGA3D:
         res[13] = a[13]+b[13]
         res[14] = a[14]+b[14]
         res[15] = a[15]+b[15]
-        return res
+        return PGA3D.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -253,7 +276,7 @@ class PGA3D:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
@@ -270,11 +293,11 @@ class PGA3D:
         res[13] = a[13]-b[13]
         res[14] = a[14]-b[14]
         res[15] = a[15]-b[15]
-        return res
+        return PGA3D.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
@@ -291,11 +314,11 @@ class PGA3D:
         res[13] = a*b[13]
         res[14] = a*b[14]
         res[15] = a*b[15]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def muls(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
@@ -312,11 +335,11 @@ class PGA3D:
         res[13] = a[13]*b
         res[14] = a[14]*b
         res[15] = a[15]*b
-        return res
+        return PGA3D.fromarray(res)
 
 
     def sadd(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
@@ -333,11 +356,11 @@ class PGA3D:
         res[13] = b[13]
         res[14] = b[14]
         res[15] = b[15]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def adds(a,b):
-        res = PGA3D()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
@@ -354,11 +377,11 @@ class PGA3D:
         res[13] = a[13]
         res[14] = a[14]
         res[15] = a[15]
-        return res
+        return PGA3D.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/quat.py
+++ b/codegen/python/quat.py
@@ -17,9 +17,32 @@ class QUAT:
         self._base = ["1", "e1", "e2", "e12"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new QUAT from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of QUAT.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,48 +61,48 @@ class QUAT:
         
         Reverse the order of the basis blades.
         """
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
         res[3]=-a[3]
-        return res
+        return QUAT.fromarray(res)
 
     def Dual(a):
         """QUAT.Dual
         
         Poincare duality operator.
         """
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=-a[3]
         res[1]=-a[2]
         res[2]=a[1]
         res[3]=a[0]
-        return res
+        return QUAT.fromarray(res)
 
     def Conjugate(a):
         """QUAT.Conjugate
         
         Clifford Conjugation
         """
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=-a[3]
-        return res
+        return QUAT.fromarray(res)
 
     def Involute(a):
         """QUAT.Involute
         
         Main involution
         """
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=a[3]
-        return res
+        return QUAT.fromarray(res)
 
     def __mul__(a,b):
         """QUAT.Mul
@@ -88,39 +111,39 @@ class QUAT:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]-b[1]*a[1]-b[2]*a[2]-b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]+b[3]*a[2]-b[2]*a[3]
         res[2]=b[2]*a[0]-b[3]*a[1]+b[0]*a[2]+b[1]*a[3]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return QUAT.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return QUAT.fromarray(res)
 
 
     def __and__(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[3]=b[3]*a[3]
         res[2]=b[2]*a[3]+b[3]*a[2]
         res[1]=b[1]*a[3]+b[3]*a[1]
         res[0]=b[0]*a[3]+b[1]*a[2]-b[2]*a[1]+b[3]*a[0]
-        return res
+        return QUAT.fromarray(res)
 
 
     def __or__(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]-b[1]*a[1]-b[2]*a[2]-b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]+b[3]*a[2]-b[2]*a[3]
         res[2]=b[2]*a[0]-b[3]*a[1]+b[0]*a[2]+b[1]*a[3]
         res[3]=b[3]*a[0]+b[0]*a[3]
-        return res
+        return QUAT.fromarray(res)
 
 
     def __add__(a,b):
@@ -130,12 +153,12 @@ class QUAT:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
         res[3] = a[3]+b[3]
-        return res
+        return QUAT.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -145,52 +168,52 @@ class QUAT:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
         res[3] = a[3]-b[3]
-        return res
+        return QUAT.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
         res[3] = a*b[3]
-        return res
+        return QUAT.fromarray(res)
 
 
     def muls(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
         res[3] = a[3]*b
-        return res
+        return QUAT.fromarray(res)
 
 
     def sadd(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
         res[3] = b[3]
-        return res
+        return QUAT.fromarray(res)
 
 
     def adds(a,b):
-        res = QUAT()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
         res[3] = a[3]
-        return res
+        return QUAT.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/r2.py
+++ b/codegen/python/r2.py
@@ -17,9 +17,32 @@ class R2:
         self._base = ["1", "e1", "e2", "e12"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new R2 from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of R2.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,48 +61,48 @@ class R2:
         
         Reverse the order of the basis blades.
         """
-        res = R2()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
         res[3]=-a[3]
-        return res
+        return R2.fromarray(res)
 
     def Dual(a):
         """R2.Dual
         
         Poincare duality operator.
         """
-        res = R2()
+        res = a.mvec.copy()
         res[0]=-a[3]
         res[1]=a[2]
         res[2]=-a[1]
         res[3]=a[0]
-        return res
+        return R2.fromarray(res)
 
     def Conjugate(a):
         """R2.Conjugate
         
         Clifford Conjugation
         """
-        res = R2()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=-a[3]
-        return res
+        return R2.fromarray(res)
 
     def Involute(a):
         """R2.Involute
         
         Main involution
         """
-        res = R2()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
         res[3]=a[3]
-        return res
+        return R2.fromarray(res)
 
     def __mul__(a,b):
         """R2.Mul
@@ -88,39 +111,39 @@ class R2:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = R2()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]-b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[3]*a[2]+b[2]*a[3]
         res[2]=b[2]*a[0]+b[3]*a[1]+b[0]*a[2]-b[1]*a[3]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return R2.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
         res[3]=b[3]*a[0]+b[2]*a[1]-b[1]*a[2]+b[0]*a[3]
-        return res
+        return R2.fromarray(res)
 
 
     def __and__(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[3]=b[3]*a[3]
         res[2]=b[2]*a[3]+b[3]*a[2]
         res[1]=b[1]*a[3]+b[3]*a[1]
         res[0]=b[0]*a[3]+b[1]*a[2]-b[2]*a[1]+b[3]*a[0]
-        return res
+        return R2.fromarray(res)
 
 
     def __or__(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]-b[3]*a[3]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[3]*a[2]+b[2]*a[3]
         res[2]=b[2]*a[0]+b[3]*a[1]+b[0]*a[2]-b[1]*a[3]
         res[3]=b[3]*a[0]+b[0]*a[3]
-        return res
+        return R2.fromarray(res)
 
 
     def __add__(a,b):
@@ -130,12 +153,12 @@ class R2:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
         res[3] = a[3]+b[3]
-        return res
+        return R2.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -145,52 +168,52 @@ class R2:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
         res[3] = a[3]-b[3]
-        return res
+        return R2.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
         res[3] = a*b[3]
-        return res
+        return R2.fromarray(res)
 
 
     def muls(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
         res[3] = a[3]*b
-        return res
+        return R2.fromarray(res)
 
 
     def sadd(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
         res[3] = b[3]
-        return res
+        return R2.fromarray(res)
 
 
     def adds(a,b):
-        res = R2()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
         res[3] = a[3]
-        return res
+        return R2.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/r3.py
+++ b/codegen/python/r3.py
@@ -17,9 +17,32 @@ class R3:
         self._base = ["1", "e1", "e2", "e3", "e12", "e13", "e23", "e123"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new R3 from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of R3.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,7 +61,7 @@ class R3:
         
         Reverse the order of the basis blades.
         """
-        res = R3()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
@@ -47,14 +70,14 @@ class R3:
         res[5]=-a[5]
         res[6]=-a[6]
         res[7]=-a[7]
-        return res
+        return R3.fromarray(res)
 
     def Dual(a):
         """R3.Dual
         
         Poincare duality operator.
         """
-        res = R3()
+        res = a.mvec.copy()
         res[0]=-a[7]
         res[1]=-a[6]
         res[2]=a[5]
@@ -63,14 +86,14 @@ class R3:
         res[5]=-a[2]
         res[6]=a[1]
         res[7]=a[0]
-        return res
+        return R3.fromarray(res)
 
     def Conjugate(a):
         """R3.Conjugate
         
         Clifford Conjugation
         """
-        res = R3()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -79,14 +102,14 @@ class R3:
         res[5]=-a[5]
         res[6]=-a[6]
         res[7]=a[7]
-        return res
+        return R3.fromarray(res)
 
     def Involute(a):
         """R3.Involute
         
         Main involution
         """
-        res = R3()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -95,7 +118,7 @@ class R3:
         res[5]=a[5]
         res[6]=a[6]
         res[7]=-a[7]
-        return res
+        return R3.fromarray(res)
 
     def __mul__(a,b):
         """R3.Mul
@@ -104,7 +127,7 @@ class R3:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = R3()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]-b[4]*a[4]-b[5]*a[5]-b[6]*a[6]-b[7]*a[7]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[4]*a[2]-b[5]*a[3]+b[2]*a[4]+b[3]*a[5]-b[7]*a[6]-b[6]*a[7]
         res[2]=b[2]*a[0]+b[4]*a[1]+b[0]*a[2]-b[6]*a[3]-b[1]*a[4]+b[7]*a[5]+b[3]*a[6]+b[5]*a[7]
@@ -113,11 +136,11 @@ class R3:
         res[5]=b[5]*a[0]+b[3]*a[1]-b[7]*a[2]-b[1]*a[3]+b[6]*a[4]+b[0]*a[5]-b[4]*a[6]-b[2]*a[7]
         res[6]=b[6]*a[0]+b[7]*a[1]+b[3]*a[2]-b[2]*a[3]-b[5]*a[4]+b[4]*a[5]+b[0]*a[6]+b[1]*a[7]
         res[7]=b[7]*a[0]+b[6]*a[1]-b[5]*a[2]+b[4]*a[3]+b[3]*a[4]-b[2]*a[5]+b[1]*a[6]+b[0]*a[7]
-        return res
+        return R3.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
@@ -126,11 +149,11 @@ class R3:
         res[5]=b[5]*a[0]+b[3]*a[1]-b[1]*a[3]+b[0]*a[5]
         res[6]=b[6]*a[0]+b[3]*a[2]-b[2]*a[3]+b[0]*a[6]
         res[7]=b[7]*a[0]+b[6]*a[1]-b[5]*a[2]+b[4]*a[3]+b[3]*a[4]-b[2]*a[5]+b[1]*a[6]+b[0]*a[7]
-        return res
+        return R3.fromarray(res)
 
 
     def __and__(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[7]=b[7]*a[7]
         res[6]=b[6]*a[7]+b[7]*a[6]
         res[5]=b[5]*a[7]+b[7]*a[5]
@@ -139,11 +162,11 @@ class R3:
         res[2]=b[2]*a[7]+b[4]*a[6]-b[6]*a[4]+b[7]*a[2]
         res[1]=b[1]*a[7]+b[4]*a[5]-b[5]*a[4]+b[7]*a[1]
         res[0]=b[0]*a[7]+b[1]*a[6]-b[2]*a[5]+b[3]*a[4]+b[4]*a[3]-b[5]*a[2]+b[6]*a[1]+b[7]*a[0]
-        return res
+        return R3.fromarray(res)
 
 
     def __or__(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]-b[4]*a[4]-b[5]*a[5]-b[6]*a[6]-b[7]*a[7]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[4]*a[2]-b[5]*a[3]+b[2]*a[4]+b[3]*a[5]-b[7]*a[6]-b[6]*a[7]
         res[2]=b[2]*a[0]+b[4]*a[1]+b[0]*a[2]-b[6]*a[3]-b[1]*a[4]+b[7]*a[5]+b[3]*a[6]+b[5]*a[7]
@@ -152,7 +175,7 @@ class R3:
         res[5]=b[5]*a[0]-b[7]*a[2]+b[0]*a[5]-b[2]*a[7]
         res[6]=b[6]*a[0]+b[7]*a[1]+b[0]*a[6]+b[1]*a[7]
         res[7]=b[7]*a[0]+b[0]*a[7]
-        return res
+        return R3.fromarray(res)
 
 
     def __add__(a,b):
@@ -162,7 +185,7 @@ class R3:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
@@ -171,7 +194,7 @@ class R3:
         res[5] = a[5]+b[5]
         res[6] = a[6]+b[6]
         res[7] = a[7]+b[7]
-        return res
+        return R3.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -181,7 +204,7 @@ class R3:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
@@ -190,11 +213,11 @@ class R3:
         res[5] = a[5]-b[5]
         res[6] = a[6]-b[6]
         res[7] = a[7]-b[7]
-        return res
+        return R3.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
@@ -203,11 +226,11 @@ class R3:
         res[5] = a*b[5]
         res[6] = a*b[6]
         res[7] = a*b[7]
-        return res
+        return R3.fromarray(res)
 
 
     def muls(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
@@ -216,11 +239,11 @@ class R3:
         res[5] = a[5]*b
         res[6] = a[6]*b
         res[7] = a[7]*b
-        return res
+        return R3.fromarray(res)
 
 
     def sadd(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
@@ -229,11 +252,11 @@ class R3:
         res[5] = b[5]
         res[6] = b[6]
         res[7] = b[7]
-        return res
+        return R3.fromarray(res)
 
 
     def adds(a,b):
-        res = R3()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
@@ -242,11 +265,11 @@ class R3:
         res[5] = a[5]
         res[6] = a[6]
         res[7] = a[7]
-        return res
+        return R3.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/spacetime.py
+++ b/codegen/python/spacetime.py
@@ -17,9 +17,32 @@ class SPACETIME:
         self._base = ["1", "e1", "e2", "e3", "e4", "e12", "e13", "e14", "e23", "e24", "e34", "e123", "e124", "e134", "e234", "e1234"]
         if (value != 0):
             self.mvec[index] = value
+            
+    @classmethod
+    def fromarray(cls, array):
+        """Initiate a new SPACETIME from an array-like object.
+
+        The first axis of the array is assumed to correspond to the elements
+        of the algebra, and needs to have the same length. Any other dimensions
+        are left unchanged, and should have simple operations such as addition 
+        and multiplication defined. NumPy arrays are therefore a perfect 
+        candidate. 
+
+        :param array: array-like object whose length is the dimension of the algebra.
+        :return: new instance of SPACETIME.
+        """
+        self = cls()
+        if len(array) != len(self):
+            raise TypeError('length of array must be identical to the dimension '
+                            'of the algebra.')
+        self.mvec = array
+        return self
         
     def __str__(self):
-        res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if math.fabs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        if isinstance(self.mvec, list):
+            res = ' + '.join(filter(None, [("%.7f" % x).rstrip("0").rstrip(".")+(["",self._base[i]][i>0]) if abs(x) > 0.000001 else None for i,x in enumerate(self)]))
+        else:  # Assume array-like, redirect str conversion
+            res = str(self.mvec)
         if (res == ''):
             return "0"
         return res
@@ -38,7 +61,7 @@ class SPACETIME:
         
         Reverse the order of the basis blades.
         """
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=a[1]
         res[2]=a[2]
@@ -55,14 +78,14 @@ class SPACETIME:
         res[13]=-a[13]
         res[14]=-a[14]
         res[15]=a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
     def Dual(a):
         """SPACETIME.Dual
         
         Poincare duality operator.
         """
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=-a[15]
         res[1]=a[14]
         res[2]=-a[13]
@@ -79,14 +102,14 @@ class SPACETIME:
         res[13]=a[2]
         res[14]=-a[1]
         res[15]=a[0]
-        return res
+        return SPACETIME.fromarray(res)
 
     def Conjugate(a):
         """SPACETIME.Conjugate
         
         Clifford Conjugation
         """
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -103,14 +126,14 @@ class SPACETIME:
         res[13]=a[13]
         res[14]=a[14]
         res[15]=a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
     def Involute(a):
         """SPACETIME.Involute
         
         Main involution
         """
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=a[0]
         res[1]=-a[1]
         res[2]=-a[2]
@@ -127,7 +150,7 @@ class SPACETIME:
         res[13]=-a[13]
         res[14]=-a[14]
         res[15]=a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
     def __mul__(a,b):
         """SPACETIME.Mul
@@ -136,7 +159,7 @@ class SPACETIME:
         """
         if type(b) in (int, float):
             return a.muls(b)
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]-b[4]*a[4]-b[5]*a[5]-b[6]*a[6]+b[7]*a[7]-b[8]*a[8]+b[9]*a[9]+b[10]*a[10]-b[11]*a[11]+b[12]*a[12]+b[13]*a[13]+b[14]*a[14]-b[15]*a[15]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[5]*a[2]-b[6]*a[3]+b[7]*a[4]+b[2]*a[5]+b[3]*a[6]-b[4]*a[7]-b[11]*a[8]+b[12]*a[9]+b[13]*a[10]-b[8]*a[11]+b[9]*a[12]+b[10]*a[13]-b[15]*a[14]+b[14]*a[15]
         res[2]=b[2]*a[0]+b[5]*a[1]+b[0]*a[2]-b[8]*a[3]+b[9]*a[4]-b[1]*a[5]+b[11]*a[6]-b[12]*a[7]+b[3]*a[8]-b[4]*a[9]+b[14]*a[10]+b[6]*a[11]-b[7]*a[12]+b[15]*a[13]+b[10]*a[14]-b[13]*a[15]
@@ -153,11 +176,11 @@ class SPACETIME:
         res[13]=b[13]*a[0]+b[10]*a[1]-b[15]*a[2]-b[7]*a[3]+b[6]*a[4]+b[14]*a[5]+b[4]*a[6]-b[3]*a[7]-b[12]*a[8]+b[11]*a[9]+b[1]*a[10]-b[9]*a[11]+b[8]*a[12]+b[0]*a[13]-b[5]*a[14]+b[2]*a[15]
         res[14]=b[14]*a[0]+b[15]*a[1]+b[10]*a[2]-b[9]*a[3]+b[8]*a[4]-b[13]*a[5]+b[12]*a[6]-b[11]*a[7]+b[4]*a[8]-b[3]*a[9]+b[2]*a[10]+b[7]*a[11]-b[6]*a[12]+b[5]*a[13]+b[0]*a[14]-b[1]*a[15]
         res[15]=b[15]*a[0]+b[14]*a[1]-b[13]*a[2]+b[12]*a[3]-b[11]*a[4]+b[10]*a[5]-b[9]*a[6]+b[8]*a[7]+b[7]*a[8]-b[6]*a[9]+b[5]*a[10]+b[4]*a[11]-b[3]*a[12]+b[2]*a[13]-b[1]*a[14]+b[0]*a[15]
-        return res
+        return SPACETIME.fromarray(res)
     __rmul__=__mul__
 
     def __xor__(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]
         res[1]=b[1]*a[0]+b[0]*a[1]
         res[2]=b[2]*a[0]+b[0]*a[2]
@@ -174,11 +197,11 @@ class SPACETIME:
         res[13]=b[13]*a[0]+b[10]*a[1]-b[7]*a[3]+b[6]*a[4]+b[4]*a[6]-b[3]*a[7]+b[1]*a[10]+b[0]*a[13]
         res[14]=b[14]*a[0]+b[10]*a[2]-b[9]*a[3]+b[8]*a[4]+b[4]*a[8]-b[3]*a[9]+b[2]*a[10]+b[0]*a[14]
         res[15]=b[15]*a[0]+b[14]*a[1]-b[13]*a[2]+b[12]*a[3]-b[11]*a[4]+b[10]*a[5]-b[9]*a[6]+b[8]*a[7]+b[7]*a[8]-b[6]*a[9]+b[5]*a[10]+b[4]*a[11]-b[3]*a[12]+b[2]*a[13]-b[1]*a[14]+b[0]*a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def __and__(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[15]=b[15]*a[15]
         res[14]=b[14]*a[15]+b[15]*a[14]
         res[13]=b[13]*a[15]+b[15]*a[13]
@@ -195,11 +218,11 @@ class SPACETIME:
         res[2]=b[2]*a[15]+b[5]*a[14]-b[8]*a[12]+b[9]*a[11]+b[11]*a[9]-b[12]*a[8]+b[14]*a[5]+b[15]*a[2]
         res[1]=b[1]*a[15]+b[5]*a[13]-b[6]*a[12]+b[7]*a[11]+b[11]*a[7]-b[12]*a[6]+b[13]*a[5]+b[15]*a[1]
         res[0]=b[0]*a[15]+b[1]*a[14]-b[2]*a[13]+b[3]*a[12]-b[4]*a[11]+b[5]*a[10]-b[6]*a[9]+b[7]*a[8]+b[8]*a[7]-b[9]*a[6]+b[10]*a[5]+b[11]*a[4]-b[12]*a[3]+b[13]*a[2]-b[14]*a[1]+b[15]*a[0]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def __or__(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0]=b[0]*a[0]+b[1]*a[1]+b[2]*a[2]+b[3]*a[3]-b[4]*a[4]-b[5]*a[5]-b[6]*a[6]+b[7]*a[7]-b[8]*a[8]+b[9]*a[9]+b[10]*a[10]-b[11]*a[11]+b[12]*a[12]+b[13]*a[13]+b[14]*a[14]-b[15]*a[15]
         res[1]=b[1]*a[0]+b[0]*a[1]-b[5]*a[2]-b[6]*a[3]+b[7]*a[4]+b[2]*a[5]+b[3]*a[6]-b[4]*a[7]-b[11]*a[8]+b[12]*a[9]+b[13]*a[10]-b[8]*a[11]+b[9]*a[12]+b[10]*a[13]-b[15]*a[14]+b[14]*a[15]
         res[2]=b[2]*a[0]+b[5]*a[1]+b[0]*a[2]-b[8]*a[3]+b[9]*a[4]-b[1]*a[5]+b[11]*a[6]-b[12]*a[7]+b[3]*a[8]-b[4]*a[9]+b[14]*a[10]+b[6]*a[11]-b[7]*a[12]+b[15]*a[13]+b[10]*a[14]-b[13]*a[15]
@@ -216,7 +239,7 @@ class SPACETIME:
         res[13]=b[13]*a[0]-b[15]*a[2]+b[0]*a[13]+b[2]*a[15]
         res[14]=b[14]*a[0]+b[15]*a[1]+b[0]*a[14]-b[1]*a[15]
         res[15]=b[15]*a[0]+b[0]*a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def __add__(a,b):
@@ -226,7 +249,7 @@ class SPACETIME:
         """
         if type(b) in (int, float):
             return a.adds(b)
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a[0]+b[0]
         res[1] = a[1]+b[1]
         res[2] = a[2]+b[2]
@@ -243,7 +266,7 @@ class SPACETIME:
         res[13] = a[13]+b[13]
         res[14] = a[14]+b[14]
         res[15] = a[15]+b[15]
-        return res
+        return SPACETIME.fromarray(res)
     __radd__=__add__
 
     def __sub__(a,b):
@@ -253,7 +276,7 @@ class SPACETIME:
         """
         if type(b) in (int, float):
             return a.subs(b)
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a[0]-b[0]
         res[1] = a[1]-b[1]
         res[2] = a[2]-b[2]
@@ -270,11 +293,11 @@ class SPACETIME:
         res[13] = a[13]-b[13]
         res[14] = a[14]-b[14]
         res[15] = a[15]-b[15]
-        return res
+        return SPACETIME.fromarray(res)
     __rsub__=__sub__
 
     def smul(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a*b[0]
         res[1] = a*b[1]
         res[2] = a*b[2]
@@ -291,11 +314,11 @@ class SPACETIME:
         res[13] = a*b[13]
         res[14] = a*b[14]
         res[15] = a*b[15]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def muls(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a[0]*b
         res[1] = a[1]*b
         res[2] = a[2]*b
@@ -312,11 +335,11 @@ class SPACETIME:
         res[13] = a[13]*b
         res[14] = a[14]*b
         res[15] = a[15]*b
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def sadd(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a+b[0]
         res[1] = b[1]
         res[2] = b[2]
@@ -333,11 +356,11 @@ class SPACETIME:
         res[13] = b[13]
         res[14] = b[14]
         res[15] = b[15]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def adds(a,b):
-        res = SPACETIME()
+        res = a.mvec.copy()
         res[0] = a[0]+b
         res[1] = a[1]
         res[2] = a[2]
@@ -354,11 +377,11 @@ class SPACETIME:
         res[13] = a[13]
         res[14] = a[14]
         res[15] = a[15]
-        return res
+        return SPACETIME.fromarray(res)
 
 
     def norm(a):
-        return math.sqrt(math.fabs((a * a.Conjugate())[0]))
+        return abs((a * a.Conjugate())[0])**0.5
         
     def inorm(a):
         return a.Dual().norm()

--- a/codegen/python/tests.py
+++ b/codegen/python/tests.py
@@ -1,0 +1,74 @@
+"""Tests for the python code.
+
+Does some simple testing on R2 to make sure the generated code runs as expected.
+"""
+
+import numpy as np
+from pytest import raises
+
+from r2 import R2
+
+def test_numpy_init():
+    a = np.array([1, 3, 4, 2, 4])
+    with raises(TypeError):
+        # Length is not a match for R2
+        complex = R2.fromarray(a)
+    a = np.array([1, 3, 4, 2])
+    complex = R2.fromarray(a)
+    assert complex.mvec is a
+
+
+def test_list_init():
+    """Init from a list.
+
+    Does not work for multidimensional lists, since those don't have
+    operator overloading.
+    """
+    a = [1, 3, 4, 2, 4]
+    with raises(TypeError):
+        # Length is not a match for R2
+        complex = R2.fromarray(a)
+    a = [1, 3, 4, 2]
+    complex = R2.fromarray(a)
+    assert complex.mvec is a
+
+def test_multidimensional_array():
+    """
+    Lets add an extra dimension to test if we have the magic of operator
+    overloading.
+    """
+    # Generate some arrays, to mimick complex numbers
+    a = np.zeros(shape=(4, 3))
+    b = np.zeros(shape=(4, 3))
+    a[0] = np.linspace(0, 10, 3)
+    b[0] = np.linspace(0, 1, 3)
+    a[-1] = np.linspace(10, 20, 3)
+    b[-1] = np.linspace(10, 11, 3)
+
+    # Turn them into complex numbers
+    a_complex = a[0] + 1j * a[3]
+    b_complex = b[0] + 1j * b[3]
+    a_alg = R2.fromarray(a)
+    b_alg = R2.fromarray(b)
+
+    # Firstly, check if the shapes haven't been mangled
+    for i, (a_i, b_i) in enumerate(zip(a_alg, b_alg)):
+        np.testing.assert_equal(a_i, a[i])
+        np.testing.assert_equal(b_i, b[i])
+
+    # Test norm
+    norm2_a = a_complex * a_complex.conj()
+    norm2_a_alg = a_alg * a_alg.Conjugate()
+
+    np.testing.assert_almost_equal(np.real(norm2_a), norm2_a_alg[0])
+    np.testing.assert_almost_equal(np.real(norm2_a), a_alg.norm()**2)
+    for i in range(1, 4):
+        np.testing.assert_almost_equal(norm2_a_alg[i], np.zeros(shape=3))
+
+    # Test the operators which should give the same results for complex and
+    # the algebra
+    operators = ['__mul__', '__add__', '__sub__']
+    for operator in operators:
+        complex_result = getattr(a_complex, operator)(b_complex)
+        result = getattr(a_alg, operator)(b_alg)
+        np.testing.assert_almost_equal(np.real(complex_result), result[0])


### PR DESCRIPTION
I added an alternative constructor `fromarray`, which allows the user to initiate from an array-like object instead, tested with numpy.

This should greatly enhance performance when dealing with large amounts of c-numbers.

Features:
- [x] Initiate from (numpy) array.
- [x] Simple test for R2 to check for equivalence with the numpy.complex datatype.