### PR TITLE
Bugfix in IPNS for points and pointpairs

### DIFF
--- a/ganja.js
+++ b/ganja.js
@@ -1023,7 +1023,7 @@
           if (options.ipns) x=x.Dual;
           // tp = { 0:unknown 1:point 2:line, 3:plane, 4:circle, 5:sphere
           var X2 = (x.Mul(x)).s, tp=0, weight2, opnix = ni.Wedge(x), ipnix = ni.LDot(x),
-              attitude, pos, normal, tg,btg,epsilon = 0.001/(options.scale||1), I3=Element.Coeff(16,-1);
+              attitude, pos, normal, tg,btg,epsilon = 0.000001/(options.scale||1), I3=Element.Coeff(16,-1);
           var x2zero = Math.abs(X2) < epsilon, ipnixzero = ipnix.VLength < epsilon, opnixzero = opnix.VLength < epsilon;
           if (opnixzero && ipnixzero) {                 // free flat
           } else if (opnixzero && !ipnixzero) {         // bound flat (lines)
@@ -1044,6 +1044,7 @@
             }
           } else if (!opnixzero && ipnixzero) {         // dual bound flat
           } else if (x2zero) {                          // bound vec,biv,tri (points)
+            if (options.ipns) x=x.Dual;
             attitude = ni.Wedge(no).LDot(ni.Wedge(x));
             pos = [...(Element.LDot(1/(ni.LDot(x)).s,x)).slice(1,4)].map(x=>-x);
             tp=1;


### PR DESCRIPTION
This pull request fixes the usage of IPNS representation.
Consider a point in IPNS:

```
Algebra(4,1,()=>{
    var x4a = new Element();
	x4a[1] = 0.2458840872748782; // e1
	x4a[2] = 0.3124999999999999; // e2
	x4a[3] = 0.3031250000000001; // e3
	x4a[4] = -0.3750000000000001; // ep
	x4a[5] = 0.6249999999999999; // em
    var canvas = this.graph(
       ()=> { return [0x000000, x4a, "x4a"]; },
		{conformal:true,gl:true, animate: true, ipns:true, noZ:true, thresh:0.05});
	document.body.appendChild(canvas);
});
```

Ganja.js will not render this point although it is a point in IPNS.
This pull request fixes this. Now the point is rendered.

Also an epsilon was decreased due to a more reliable detection of a point pair.