### PR TITLE
Script error annotations in ACE

### DIFF
--- a/examples/coffeeshop.html
+++ b/examples/coffeeshop.html
@@ -488,6 +488,7 @@
   
   // Link run handler.
     els.run.onclick=(e)=>{
+      editor.getSession().clearAnnotations();
       var f = els.sample.contentDocument.body.firstChild; while (f && !(f instanceof els.sample.contentWindow.HTMLScriptElement)) f = f.nextElementSibling; f = f&&f.nextElementSibling;
       if (f) while (true) { var g=f.nextSibling; els.sample.contentDocument.body.removeChild(f); if (!g) break; f=g; }
       try { 
@@ -520,6 +521,27 @@
     // setup iframe props.
       els.sample.contentDocument.body.style = "margin:0; padding:0;";
       postRun();
+      els.sample.contentWindow.addEventListener('error', function(e) {
+        // show error in HTML
+        els.sample.contentDocument.body.innerHTML+=`<PRE>${e.message}</PRE>`;
+        // show error in ace editor
+        var row = e.lineno;
+        // e.lineno is one off in same cases... fixing that, otherwise it looks strange
+        // Chrome
+        if (e.message.includes("Unexpected identifier")) {
+          row--;
+        }
+        // Mozilla
+        if (e.message.includes("unexpected token: identifier")) {
+          row--;
+        }
+        editor.getSession().setAnnotations([{
+          row,
+          column: e.colno,
+          text: e.message,
+          type: "error" // or "warning"
+        }]);
+      });
     // Grab the source and update the editor.  
       var scr = [...els.sample.contentDocument.querySelectorAll("script")].pop();
       if (window.editor && scr) {


### PR DESCRIPTION
I tested this on Chrome and Firefox, it will display the error message in the iframe (again) plus in Ace editor as annotation:

![image](https://user-images.githubusercontent.com/5236548/106017364-ad280300-60c0-11eb-8b35-956d55ab4ad2.png)

![image](https://user-images.githubusercontent.com/5236548/106017443-bf09a600-60c0-11eb-9bff-ee71128e3fa2.png)

Reason why old error message was gone:

```js
      try { 
        //els.sample.contentWindow.eval( editor.getValue() ); 
        var script = document.createElement("script");
        script.type = "module";
        script.textContent = editor.getValue();
        els.sample.contentDocument.head.appendChild(script);
        setTimeout(()=>postRun(),1); // for fox.
      } catch (e) {
        var line = e.stack.toString().match(/\, <anonymous>:(\d+)/);
        if (line && line[1]) {
          line = line[1]|0;
          els.sample.contentDocument.body.innerHTML+=`<PRE>${e.message+"\n   at line : "+line}</PRE>`;
        } else {
          els.sample.contentDocument.body.innerHTML+=`<PRE>${e.message+"\n"+e.stack}</PRE>`;
        }
      }
```

And only the commented `eval` actually caused the `try-catch`... the new script module fires `window.onerror` instead.