### PR TITLE
Add Inner Product to coffeeshop help and change Left Contraction to \rfloor

### DIFF
--- a/examples/coffeeshop.html
+++ b/examples/coffeeshop.html
@@ -220,9 +220,10 @@
               <TR><TH>Operator<TH>Javascript<TH>Name
             </THEAD>
               <TR><TD>\(a*b\)<TD>a*b<TD>Geometric Product
+              <TR><TD>\(a\bullet b\)<TD>a|b<TD>Inner Product
               <TR><TD>\(a\wedge b\)<TD>a^b<TD>Outer Product
               <TR><TD>\(a\vee b\)<TD>a&b<TD>Regressive Product
-              <TR><TD>\(a\cdot b\)<TD>a&lt;&lt;b<TD>Left Contraction
+              <TR><TD>\(a\rfloor b\)<TD>a&lt;&lt;b<TD>Left Contraction
               <TR><TD>\(a*b*\tilde a\)<TD>a>>>b<TD>Sandwich Product
               <TR><TD>\(\tilde a\)<TD>~a<TD>Conjugate
               <TR><TD>\(\bar a\)<TD>!a<TD>Dual

--- a/examples/coffeeshop.html
+++ b/examples/coffeeshop.html
@@ -220,7 +220,7 @@
               <TR><TH>Operator<TH>Javascript<TH>Name
             </THEAD>
               <TR><TD>\(a*b\)<TD>a*b<TD>Geometric Product
-              <TR><TD>\(a\bullet b\)<TD>a|b<TD>Inner Product
+              <TR><TD>\(a\cdot b\)<TD>a|b<TD>Inner Product
               <TR><TD>\(a\wedge b\)<TD>a^b<TD>Outer Product
               <TR><TD>\(a\vee b\)<TD>a&b<TD>Regressive Product
               <TR><TD>\(a\rfloor b\)<TD>a&lt;&lt;b<TD>Left Contraction


### PR DESCRIPTION
I couldn't find the information about `|` (bitwise or operator) being the Inner Product and then I found a maybe better symbol for Left Contraction.

This is how it looks with PR:

![image](https://user-images.githubusercontent.com/5236548/106386254-698d0c00-63d4-11eb-8d78-727ca983d072.png)

Before:

![image](https://user-images.githubusercontent.com/5236548/106386040-5e85ac00-63d3-11eb-91cc-87c4034ef8b6.png)

I just wanted to add the Inner Product first, but then I found the `\rfloor` for Left Contration on Wikipedia:

![image](https://user-images.githubusercontent.com/5236548/106386141-e370c580-63d3-11eb-9dd6-04d76d2aa723.png)

Not sure if this is even welcome, seems like every GA project has another notation, so I could just revert the Left Contration and keep the added Inner Product to the PR 🤔 