### PR TITLE
warn for losing unsaved changes

### DIFF
--- a/examples/coffeeshop.html
+++ b/examples/coffeeshop.html
@@ -717,6 +717,12 @@
         })
       });
     }    
+  // warn before exit
+    window.onbeforeunload = (e)=>{
+      if(!els.save.classList.contains('active')) return;
+      e.preventDefault(); // firefox
+      e.returnValue = ''; // chrome
+    };
     
   // load custom stash
     function loadStash(closeAll){


### PR DESCRIPTION
After losing my changes when pressing the wrong keyboard shortcut, this did not seem an unnecessary luxury.
Tested in Chrome and Firefox